### PR TITLE
Commit right after the file processing is finished.

### DIFF
--- a/src/main/java/com/fordfrog/ruian2pgsql/convertors/MainConvertor.java
+++ b/src/main/java/com/fordfrog/ruian2pgsql/convertors/MainConvertor.java
@@ -111,9 +111,8 @@ public class MainConvertor {
 
             for (final Path file : getInputFiles(inputDirPath)) {
                 processFile(con, file, logFile);
+                con.commit();
             }
-
-            con.commit();
 
             Utils.printToLog(logFile, "Total duration: "
                     + (System.currentTimeMillis() - startTimestamp) + " ms");


### PR DESCRIPTION
This should prevent long blocking of all tables. Furthermore, it makes sure, that in case of unexpected end of execution, all consistent data are already committed in the database.
