### PR TITLE
Updating JDBC driver to the version 9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,9 +54,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>[9.1-901-1.jdbc4,)</version>
+            <version>9.4-1201-jdbc41</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Has the possibility to define default schema (currentSchema) in the connection string.