### PR TITLE
	Oprava mazání parcel

### DIFF
--- a/src/main/java/com/fordfrog/ruian2pgsql/convertors/ZaniklyPrvekConvertor.java
+++ b/src/main/java/com/fordfrog/ruian2pgsql/convertors/ZaniklyPrvekConvertor.java
@@ -322,7 +322,7 @@ public class ZaniklyPrvekConvertor extends AbstractSaveConvertor<ZaniklyPrvek> {
 
         pstmUpdateParcela.clearParameters();
         pstmUpdateParcela.setLong(1, item.getIdTransakce());
-        pstmUpdateParcela.setInt(2, item.getPrvekId().intValue());
+        pstmUpdateParcela.setLong(2, item.getPrvekId());
         pstmUpdateParcela.setLong(3, item.getIdTransakce());
         pstmUpdateParcela.execute();
 


### PR DESCRIPTION
Chybička se vloudila. V databázi jsou id parcely jako bigint a zcela oprávněně:
SELECT MAX(id) FROM rn_parcela;
56054829010