### PR TITLE
Oprava java.lang.NullPointerException v ZsjConvertor.java

### DIFF
--- a/src/main/java/com/fordfrog/ruian2pgsql/convertors/ZsjConvertor.java
+++ b/src/main/java/com/fordfrog/ruian2pgsql/convertors/ZsjConvertor.java
@@ -125,7 +125,7 @@ public class ZsjConvertor extends AbstractSaveConvertor<Zsj> {
         pstm.setString(index++, item.getMluvCharPad5());
         pstm.setString(index++, item.getMluvCharPad6());
         pstm.setString(index++, item.getMluvCharPad7());
-        pstm.setLong(index++, item.getVymera());
+        pstmEx.setLong(index++, item.getVymera());
         pstmEx.setDate(index++, item.getPlatiOd());
         pstmEx.setBoolean(index++, item.getZmenaGrafiky());
         pstm.setLong(index++, item.getNzIdGlobalni());


### PR DESCRIPTION
Oprava java.lang.NullPointerException v případě že změnový soubor
neobsahuje element <zji:Vymera> u základních sídelních jednotek (ZSJ)