### PR TITLE
Zruseni okresu 3100 - Hlavní město Praha

### DIFF
--- a/README.cs.md
+++ b/README.cs.md
@@ -94,6 +94,9 @@ Seznam plánovaných funkcí je na [wiki](https://github.com/fordfrog/ruian2pgsq
 ruian2pgsql je distribuovaný pod MIT licencí.
 
 ## Changelog
+## Version 1.7.1
+* Sloupeček okres_kod v tabulce rn_obec a rn_orp může být nyní nastaven na NULL. 
+
 ## Version 1.7.0
 
 * Přidána podpora pro VFR ver. 3.1 (David Pavlíček)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ ruian2pgsql is distributed under MIT license.
 [ČÚZK - Veřejný dálkový přístup](https://vdp.cuzk.cz/vdp/ruian/vymennyformat/vyhledej)
 
 ## Changelog
+## Version 1.7.1
+* Column okres_kod in table rn_obec and rn_orp can now be set to NULL. 
+
 ## Version 1.7.0
 * Added support for VFR ver. 3.1 (David Pavlíček)
 * Added support for deleting items of all imported tables (David Pavlíček) 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.fordfrog</groupId>
     <artifactId>ruian2pgsql</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <packaging>jar</packaging>
 
     <name>ruian2pgsql</name>

--- a/src/main/java/com/fordfrog/ruian2pgsql/convertors/ObecConvertor.java
+++ b/src/main/java/com/fordfrog/ruian2pgsql/convertors/ObecConvertor.java
@@ -126,7 +126,7 @@ public class ObecConvertor extends AbstractSaveConvertor<Obec> {
         int index = 1;
         pstm.setString(index++, item.getNazev());
         pstmEx.setBoolean(index++, item.getNespravny());
-        pstm.setInt(index++, item.getOkresKod());
+        pstmEx.setInt(index++, item.getOkresKod());
         pstm.setInt(index++, item.getPouKod());
         pstm.setString(index++, item.getNutsLau());
         pstm.setString(index++, item.getMluvCharPad2());

--- a/src/main/java/com/fordfrog/ruian2pgsql/convertors/OrpConvertor.java
+++ b/src/main/java/com/fordfrog/ruian2pgsql/convertors/OrpConvertor.java
@@ -118,7 +118,7 @@ public class OrpConvertor extends AbstractSaveConvertor<Orp> {
         }
 
         pstmEx.setDate(index++, item.getDatumVzniku());
-        pstm.setInt(index++, item.getOkresKod());
+        pstmEx.setInt(index++, item.getOkresKod());
         pstm.setInt(index++, item.getKod());
 
         if (update) {


### PR DESCRIPTION
V RUIANu dojde 1. 7. 2022 ke zrušení okresu 3100 - Hlavní město Praha. Z tohoto důvodu bude nutné nastavit atribut okres_kod na NULL v tabulkách rn_obec a rn_orp. V současné době toto není možné - atributy nejsou volitelné. PR mění typ atributu na volitelný a tedy s možností nastavení na NULL. 